### PR TITLE
[fix] Properly set and save upload password, allowing empty one

### DIFF
--- a/conf/config.local.php
+++ b/conf/config.local.php
@@ -51,7 +51,7 @@ $cfg['link_name_length'] = 8;
  * $cfg['upload_password'] = array('psw1', 'psw2'); // Two passwords
  * ... and so on
  */
-$cfg['upload_password'] = array('YNH_UPLOAD_PASSWORD');
+$cfg['upload_password'] = array(YNH_UPLOAD_PASSWORD);
 /* An empty admin password will disable the classic admin password
  * authentication.
  */

--- a/scripts/install
+++ b/scripts/install
@@ -25,8 +25,16 @@ fi
 
 # Save specific settings
 sudo yunohost app setting jirafeau admin_user -v $admin_user
-sudo yunohost app setting jirafeau upload_password -v $upload_password
 sudo yunohost app setting jirafeau is_public -v $is_public
+
+# Set and save upload password, allowing an empty one
+if [[ -z "$upload_password" ]]; then
+    sed -i "s@YNH_UPLOAD_PASSWORD@@g" ../conf/config.local.php
+    sudo yunohost app setting jirafeau upload_password -v ''
+else
+    sed -i "s@YNH_UPLOAD_PASSWORD@'$upload_password'@g" ../conf/config.local.php
+    sudo yunohost app setting jirafeau upload_password -v $upload_password
+fi
 
 # Copy files to the right place
 final_path=/var/www/jirafeau
@@ -37,7 +45,6 @@ sed -i "s@YNH_DOMAIN@$domain@g" ../conf/config.local.php
 sed -i "s@YNH_WWW_PATH@$path@g" ../conf/config.local.php
 sed -i "s@YNH_VAR_ROOT@$var_root@g" ../conf/config.local.php
 sed -i "s@YNH_ADMIN_USER@$admin_user@g" ../conf/config.local.php
-sed -i "s@YNH_UPLOAD_PASSWORD@$upload_password@g" ../conf/config.local.php
 sudo cp ../conf/config.local.php $final_path/lib
 sudo rm $final_path/install.php
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -9,6 +9,13 @@ is_public=$(sudo yunohost app setting jirafeau is_public)
 # Remove trailing "/" for next commands
 path=${path%/}
 
+# Set upload password, allowing an empty one
+if [[ -z "$upload_password" ]]; then
+    sed -i "s@YNH_UPLOAD_PASSWORD@@g" ../conf/config.local.php
+else
+    sed -i "s@YNH_UPLOAD_PASSWORD@'$upload_password'@g" ../conf/config.local.php
+fi
+
 # Copy files to the right place
 final_path=/var/www/jirafeau
 var_root=/home/yunohost.app/jirafeau
@@ -19,7 +26,6 @@ sed -i "s@YNH_DOMAIN@$domain@g" ../conf/config.local.php
 sed -i "s@YNH_WWW_PATH@$path@g" ../conf/config.local.php
 sed -i "s@YNH_VAR_ROOT@$var_root@g" ../conf/config.local.php
 sed -i "s@YNH_ADMIN_USER@$admin_user@g" ../conf/config.local.php
-sed -i "s@YNH_UPLOAD_PASSWORD@$upload_password@g" ../conf/config.local.php
 sudo cp ../conf/config.local.php $final_path/lib
 sudo rm $final_path/install.php
 


### PR DESCRIPTION
The array `upload_password` in *config.local.php* must be empty for the upload password authentication to be disabled.

This PR checks if **upload_password** argument is empty to set and save it properly - by preventing to have an array with one empty string in the conf, which lets the upload authentication enabled.