### PR TITLE
Edit nginx configuration to allow access to functions.js.php 

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -6,6 +6,16 @@ location YNH_WWW_LOCATION {
   client_max_body_size 10G;
   index index.php;
   try_files $uri $uri/ index.php;
+
+  location ~ ^YNH_WWW_PATH/lib/functions.js.php {
+    fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+    fastcgi_pass unix:/var/run/php5-fpm-jirafeau.sock;
+    fastcgi_index index.php;
+    include fastcgi_params;
+    fastcgi_param REMOTE_USER     $remote_user;
+    fastcgi_param PATH_INFO       $fastcgi_path_info;
+    fastcgi_param SCRIPT_FILENAME $request_filename;
+  }
   location ~ ^YNH_WWW_PATH/lib/.*\.php {
     deny all;
   }


### PR DESCRIPTION
Hello,

With the new version Jirafeau v1.1, index.php calls functions.js.php located in the lib subdirectory.
However the configuration of nginx denies all access to lib/*.php.
So the main page is broken because all javascript functions cannot be accessed and so are not defined.

The new configuration allows access only to lib/functions.js.php in order to make index.php working again.

It is compatible with v1.0.

